### PR TITLE
Add image URL configuration for eduSummit in nitro.config.ts

### DIFF
--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -13,6 +13,9 @@ export default defineNitroConfig({
     eduSummit: {
       coupon: process.env.EDUSUMMIT_COUPON_CODE ?? "T3ST3",
       url: process.env.EDUSUMMIT_URL ?? "https://www.example.com",
+      image:
+        process.env.EDUSUMMIT_IMAGE ??
+        "https://cdn.hemocione.com.br/events/prod/uploads/private/1747765373818-edusummit.png",
     },
   },
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to allow customization of the EduSummit image via an environment variable, with a default image provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->